### PR TITLE
Improving hook_default_message_type documentation

### DIFF
--- a/message.api.php
+++ b/message.api.php
@@ -73,7 +73,20 @@ function hook_message_view_alter(&$build) {
  */
 function hook_default_message_type() {
   $defaults['main'] = entity_create('message_type', array(
+    'description' => 'Type description',
+    'argument_keys' => array(
+      '!teaser',
+      '!body',
+      '@string'
+    ),
+    'message_text' => array(
+      LANGUAGE_NONE => array(
+        array('value' => 'Example text.'),
+      ),
+    ),
+    'language' => 'en'
   ));
+
   return $defaults;
 }
 

--- a/message.api.php
+++ b/message.api.php
@@ -77,14 +77,14 @@ function hook_default_message_type() {
     'argument_keys' => array(
       '!teaser',
       '!body',
-      '@string'
+      '@string',
     ),
     'message_text' => array(
       LANGUAGE_NONE => array(
         array('value' => 'Example text.'),
       ),
     ),
-    'language' => 'en'
+    'language' => 'en',
   ));
 
   return $defaults;


### PR DESCRIPTION
Added some optional values to the $values array to make sure other developers don't get lost.
