### PR TITLE
Custom property for partial message text tokens.

### DIFF
--- a/message.info.inc
+++ b/message.info.inc
@@ -51,6 +51,16 @@ class MessageMetadataController extends EntityDefaultMetadataController {
       'sanitize' => TRUE,
     );
 
+    // Add a property listing all text values.
+    $properties['text_list'] = array(
+      'type' => 'list<text>',
+      'label' => t('Partial message text'),
+      'getter callback' => 'message_property_get_text_list',
+      'description' => t('A list of partial message text values with all replacement arguments applied.'),
+      'computed' => TRUE,
+      'sanitized' => TRUE,
+    );
+
     // Bypass entity_load() as we cannot use it here.
     $message_types = db_select('message_type', 'mt')
       ->fields('mt')

--- a/message.module
+++ b/message.module
@@ -938,6 +938,28 @@ function message_property_get_text($message, array $options) {
 }
 
 /**
+ * Entity property info getter callback for getting a list of message texts.
+ */
+function message_property_get_text_list($message, array $options) {
+  $langcode = isset($options['language']) ? $options['language']->language : LANGUAGE_NONE;
+  $message_type = $message->getType();
+  $message_type_wrapper = entity_metadata_wrapper('message_type', $message_type);
+  $property = $message_type_wrapper->language($langcode)->{MESSAGE_FIELD_MESSAGE_TEXT};
+
+  $text_list = array();
+  $text_options = array(
+    'partials' => TRUE,
+  );
+  if ($property instanceof EntityListWrapper) {
+    foreach (array_keys($property->value($options)) as $delta) {
+      $text_options['partial delta'] = $delta;
+      $text_list[$delta] = $message->getText($langcode, $text_options);
+    }
+  }
+  return $text_list;
+}
+
+/**
  * Get the values of a message property.
  *
  * The value of the message, after intersecting with the same values


### PR DESCRIPTION
Currently, AFAIK, there's no way to get a token for a single delta value for a message text. I have a message type, where text (delta 0) holds an SMS text and (delta 1) holds an email texts. Both SMS and e-mails are sent by Rules, and I need to retrieve the delta values as tokens to their respective rule.
I've added a property, that retrieves the texts as a list, so tokens can use the delta values.

In order for this to work, there's an issue with chained tokens and Entity tokens that needs to be resolved. ([See here](https://www.drupal.org/node/2126215))
