### PR TITLE
Added Cron limit to admin UI.

### DIFF
--- a/includes/message.admin.inc
+++ b/includes/message.admin.inc
@@ -83,7 +83,7 @@ function message_user_admin_settings($form_state) {
     '#type' => 'textfield',
     '#title' => t('Cron limit for message purging'),
     '#description' => t('Maximal messages to be purged on each Cron run.'),
-    '#default_value' => variable_get('message_delete_cron_limit', NULL),
+    '#default_value' => variable_get('message_delete_cron_limit', MESSAGE_PURGE_LIMIT),
     '#element_validate' => array('element_validate_integer_positive'),
     '#states' => $states,
   );

--- a/includes/message.admin.inc
+++ b/includes/message.admin.inc
@@ -79,6 +79,15 @@ function message_user_admin_settings($form_state) {
     '#states' => $states,
   );
 
+  $form['purge']['message_delete_cron_limit'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Cron limit for message purging'),
+    '#description' => t('Maximal messages to be purged on each Cron run.'),
+    '#default_value' => variable_get('message_delete_cron_limit', NULL),
+    '#element_validate' => array('element_validate_integer_positive'),
+    '#states' => $states,
+  );
+
   $options = array();
   foreach (entity_get_info() as $entity_id => $entity) {
     $options[$entity_id] = $entity['label'];


### PR DESCRIPTION
I was wondering why I had messages older than the purge time I specified in the admin UI; it turned out that my site generated more messages than `MESSAGE_PURGE_LIMIT` per Cron run.

This PR exposes this variable to the admin UI.
