### PR TITLE
Fix "All parts of a PRIMARY KEY must be NOT NULL;" error on install when using MySQL 5.7

### DIFF
--- a/message.install
+++ b/message.install
@@ -192,6 +192,7 @@ function message_schema() {
     'fields' => array(
       'mid' => array(
         'type' => 'serial',
+        'not null' => TRUE,
         'unsigned' => TRUE,
         'description' => 'The Unique ID of the message.',
       ),


### PR DESCRIPTION
Message doesn't install when using MySQL 5.7 due to the following error:

```
exception 'PDOException' with message 'SQLSTATE[42000]: Syntax error or access violation: 1171 All parts of a PRIMARY KEY must be NOT NULL; if you [error]
need NULL in a key, use UNIQUE instead'
```

In 5.7 there are more strict constraints on primary keys. So adding 'not null' fixes this (Looks like other message tables already have this).
