### PR TITLE
Remove views config errors seen in Config Inspector

### DIFF
--- a/config/optional/views.view.message.yml
+++ b/config/optional/views.view.message.yml
@@ -166,10 +166,6 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          action_title: 'With selection'
-          include_exclude: include
-          selected_actions:
-            - messaege_delete_action
           entity_type: message
           plugin_id: message_bulk_form
         mid:


### PR DESCRIPTION
Re-rolled version of: https://github.com/Gizra/message/pull/53

Config errors as seen below using Config Inspector module
![screenshot 2016-02-07 14 07 00](https://cloud.githubusercontent.com/assets/559938/12872809/dad5a078-cda4-11e5-8071-427cf74096fd.png)

I couldn't see how these settings were used and all seemed the same without them. If they are needed, schema needs to be added for them, in _message.schema.yml_? Not sure how to deal with this / optional config at the moment.

Removing these config issues allows Message UI test to run for example, so it needs to be fixed / removed. Thanks.
