### PR TITLE
Re-introduces the 'full' view mode

### DIFF
--- a/config/install/core.entity_view_mode.message.full.yml
+++ b/config/install/core.entity_view_mode.message.full.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: false
+dependencies:
+  module:
+    - message
+id: message.full
+label: 'Full content'
+targetEntityType: message
+cache: true


### PR DESCRIPTION
The 7.x version provided a 'full' view mode. This adds that back in (I encountered this while porting `message_notify`).
