### PR TITLE
Use ConfigEntityBundleBase instead

### DIFF
--- a/src/Entity/MessageType.php
+++ b/src/Entity/MessageType.php
@@ -7,7 +7,7 @@
 
 namespace Drupal\message\Entity;
 
-use Drupal\Core\Config\Entity\ConfigEntityBase;
+use Drupal\Core\Config\Entity\ConfigEntityBundleBase;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\language\ConfigurableLanguageManagerInterface;
 use Drupal\message\MessageTypeInterface;
@@ -42,7 +42,7 @@ use Drupal\message\MessageTypeInterface;
  *   }
  * )
  */
-class MessageType extends ConfigEntityBase implements MessageTypeInterface {
+class MessageType extends ConfigEntityBundleBase implements MessageTypeInterface {
 
   /**
    * The ID of this message type.


### PR DESCRIPTION
By extending `ConfigEntityBundleBase` instead of just `ConfigEntityBase`, certain hooks (such as `hook_entity_bundle_create()` and `hook_entity_bundle_delete()` are automatically invoked on behalf of message bundles.
