### PR TITLE
Remove unused classes from use statement

### DIFF
--- a/modules/message_example/message_example.tokens.inc
+++ b/modules/message_example/message_example.tokens.inc
@@ -5,9 +5,6 @@
  * Place holder for the message example module.
  */
 
-use Drupal\Component\Utility\String;
-use Drupal\Component\Utility\Xss;
-
 /**
  * Implements hook_token_info().
  *


### PR DESCRIPTION
- Removes unused 'Xss' class
- Removes outdated, and unused, 'String' class
- Fixes #110
