### PR TITLE
Token browser link on separate line

### DIFF
--- a/src/FormElement/MessageTemplateMultipleTextField.php
+++ b/src/FormElement/MessageTemplateMultipleTextField.php
@@ -71,6 +71,7 @@ class MessageTemplateMultipleTextField {
         '#theme' => 'token_tree_link',
         '#token_types' => 'all',
         '#show_restricted' => TRUE,
+        '#theme_wrappers' => ['form_element'],
       ];
     }
 


### PR DESCRIPTION
- Fixes #126 

Before:

<img width="500" alt="screen shot 2016-09-28 at 1 05 10 pm" src="https://cloud.githubusercontent.com/assets/76833/18930329/7de1085e-857c-11e6-903d-f4a922f9f21c.png">

After:

<img width="483" alt="screen shot 2016-09-28 at 1 04 42 pm" src="https://cloud.githubusercontent.com/assets/76833/18930339/82e0b390-857c-11e6-820c-1eea0f7ca8f0.png">
