### PR TITLE
Do not allow templates that are in use to be deleted.

### DIFF
--- a/src/Form/MessageTemplateDeleteConfirm.php
+++ b/src/Form/MessageTemplateDeleteConfirm.php
@@ -3,13 +3,41 @@
 namespace Drupal\message\Form;
 
 use Drupal\Core\Entity\EntityConfirmFormBase;
+use Drupal\Core\Entity\Query\QueryFactory;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides a form for message template deletion.
  */
 class MessageTemplateDeleteConfirm extends EntityConfirmFormBase {
+
+  /**
+   * The query factory to create entity queries.
+   *
+   * @var \Drupal\Core\Entity\Query\QueryFactory
+   */
+  protected $queryFactory;
+
+  /**
+   * Constructs a new MessageTemplateDeleteConfirm object.
+   *
+   * @param \Drupal\Core\Entity\Query\QueryFactory $query_factory
+   *   The entity query object.
+   */
+  public function __construct(QueryFactory $query_factory) {
+    $this->queryFactory = $query_factory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity.query')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -29,6 +57,17 @@ class MessageTemplateDeleteConfirm extends EntityConfirmFormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
+    // Check if any messages are using this template.
+    $number_messages = $this->queryFactory->get('message')
+      ->condition('template', $this->entity->id())
+      ->count()
+      ->execute();
+    if ($number_messages) {
+      $caption = '<p>' . $this->formatPlural($number_messages, '%template is used by 1 message on your site. You cannot remove this message template until you have removed all of the %template messages.', '%template is used by @count messages on your site. You may not remove %template until you have removed all of the %template messages.', ['%template' => $this->entity->label()]) . '</p>';
+      $form['#title'] = $this->getQuestion();
+      $form['description'] = ['#markup' => $caption];
+      return $form;
+    }
     return parent::buildForm($form, $form_state);
   }
 


### PR DESCRIPTION
- Fixes #123 

This mimics the approach the node module uses to disallow templates that are in use from being deleted via the UI.
