### PR TITLE
Add a dedicated kernel test for Message::getText().

### DIFF
--- a/src/Entity/Message.php
+++ b/src/Entity/Message.php
@@ -194,7 +194,7 @@ class Message extends ContentEntityBase implements MessageInterface {
   /**
    * {@inheritdoc}
    */
-  public function getText($langcode = Language::LANGCODE_NOT_SPECIFIED, $delta = FALSE) {
+  public function getText($langcode = Language::LANGCODE_NOT_SPECIFIED, $delta = NULL) {
     if (!$message_template = $this->getTemplate()) {
       // Message template does not exist any more.
       // We don't throw an exception, to make sure we don't break sites that
@@ -207,9 +207,8 @@ class Message extends ContentEntityBase implements MessageInterface {
 
     $output = $this->processArguments($message_arguments, $message_template_text);
 
-    $token_replace = $message_template->getSetting('token replace', TRUE);
-    $token_options = $message_template->getSetting('token options');
-    if (!empty($token_replace)) {
+    $token_options = $message_template->getSetting('token options', []);
+    if (!empty($token_options['token replace'])) {
       // Token should be processed.
       $output = $this->processTokens($output, !empty($token_options['clear']));
     }
@@ -226,7 +225,7 @@ class Message extends ContentEntityBase implements MessageInterface {
    *   Array with the templated text saved in the message template.
    *
    * @return array
-   *   The templated text, with the placehodlers replaced with the actual value,
+   *   The templated text, with the placeholders replaced with the actual value,
    *   if there are indeed arguments.
    */
   protected function processArguments(array $arguments, array $output) {
@@ -243,7 +242,7 @@ class Message extends ContentEntityBase implements MessageInterface {
 
         if ($value['pass message']) {
           // Pass the message object as-well.
-          $value['callback arguments']['message'] = $this;
+          $value['arguments']['message'] = $this;
         }
 
         $arguments[$key] = call_user_func_array($value['callback'], $value['arguments']);

--- a/src/Entity/MessageTemplate.php
+++ b/src/Entity/MessageTemplate.php
@@ -277,8 +277,9 @@ class MessageTemplate extends ConfigEntityBundleBase implements MessageTemplateI
     }
 
     if ($delta) {
-      // Return just the delta if it exists.
-      return isset($text[$delta]) ? $text[$delta] : '';
+      // Return just the delta if it exists. Always wrap in an array here to
+      // ensure compatibility with methods calling getText.
+      return isset($text[$delta]) ? [$text[$delta]] : [];
     }
 
     return $text;

--- a/tests/src/Kernel/MessageTemplateCreateTrait.php
+++ b/tests/src/Kernel/MessageTemplateCreateTrait.php
@@ -32,6 +32,7 @@ trait MessageTemplateCreateTrait {
   protected function createMessageTemplate($template, $label, $description, array $text, array $settings = [], $langcode = Language::LANGCODE_NOT_SPECIFIED) {
     $settings += [
       'token options' => [
+        'token replace' => TRUE,
         'clear' => FALSE,
       ],
     ];

--- a/tests/src/Kernel/MessageTest.php
+++ b/tests/src/Kernel/MessageTest.php
@@ -3,33 +3,54 @@
 namespace Drupal\Tests\message\Kernel;
 
 use Drupal\Component\Utility\Unicode;
+use Drupal\Core\Language\Language;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\message\Entity\Message;
+use Drupal\message\MessageInterface;
 use Drupal\simpletest\UserCreationTrait;
 
 /**
  * Kernel tests for the Message entity.
  *
  * @group Message
+ *
+ * @coversDefaultClass \Drupal\message\Entity\Message
  */
 class MessageTest extends KernelTestBase {
 
-  use \Drupal\Tests\message\Kernel\MessageTemplateCreateTrait;
+  use MessageTemplateCreateTrait;
   use UserCreationTrait;
 
   /**
    * {@inheritdoc}
    */
-  public static $modules = ['message', 'user', 'system'];
+  public static $modules = ['filter', 'message', 'user', 'system'];
+
+  /**
+   * Entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * A message template to test with.
+   *
+   * @var \Drupal\message\MessageTemplateInterface
+   */
+  protected $messageTemplate;
 
   /**
    * {@inheritdoc}
    */
   public function setUp() {
     parent::setUp();
+    $this->installConfig(['filter']);
     $this->installEntitySchema('message');
     $this->installEntitySchema('user');
     $this->installSchema('system', ['sequences']);
+    $this->entityTypeManager = $this->container->get('entity_type.manager');
+    $this->messageTemplate = $this->createMessageTemplate(Unicode::strtolower($this->randomMachineName()), $this->randomString(), $this->randomString(), []);
   }
 
   /**
@@ -46,14 +67,168 @@ class MessageTest extends KernelTestBase {
    * Tests getting the user.
    */
   public function testGetOwner() {
-    $template = $this->createMessageTemplate(Unicode::strtolower($this->randomMachineName()), $this->randomString(), $this->randomString(), []);
-    $message = Message::create(['template' => $template->id()]);
+    $message = Message::create(['template' => $this->messageTemplate->id()]);
     $account = $this->createUser();
     $message->setOwner($account);
     $this->assertEquals($account->id(), $message->getOwnerId());
 
     $owner = $message->getOwner();
     $this->assertEquals($account->id(), $owner->id());
+  }
+
+  /**
+   * Tests for getText.
+   *
+   * @covers ::getText
+   */
+  public function testGetText() {
+    // Test with missing message template.
+    $message = $this->entityTypeManager->getStorage('message')->create(['template' => 'no_exists']);
+    $this->assertEmpty($message->getText());
+
+    // Non-existent delta.
+    $message = $this->entityTypeManager->getStorage('message')->create(['template' => $this->messageTemplate->id()]);
+    $this->assertEmpty($message->getText(Language::LANGCODE_NOT_SPECIFIED, 123));
+
+    // Verify token clearing disabled.
+    $this->messageTemplate->setSettings([
+      'token options' => [
+        'token replace' => TRUE,
+        'clear' => FALSE,
+      ],
+    ]);
+    $this->messageTemplate->set('text', [
+      [
+        'value' => 'foo [fake:token] and [message:author:name]',
+        'format' => filter_default_format(),
+      ],
+    ]);
+    $this->messageTemplate->save();
+
+    $message = $this->entityTypeManager->getStorage('message')->create([
+      'template' => $this->messageTemplate->id(),
+    ]);
+    $text = $message->getText();
+    $this->assertEquals(1, count($text));
+    $this->assertEquals('<p>foo [fake:token] and [message:author:name]</p>' . "\n", $text[0]);
+
+    // Verify token clearing enabled.
+    $this->messageTemplate->setSettings([
+      'token options' => [
+        'token replace' => TRUE,
+        'clear' => TRUE,
+      ],
+    ]);
+    $this->messageTemplate->save();
+    $message = $this->entityTypeManager->getStorage('message')->create([
+      'template' => $this->messageTemplate->id(),
+    ]);
+    $text = $message->getText();
+    $this->assertEquals(1, count($text));
+    $this->assertEquals('<p>foo  and </p>' . "\n", $text[0]);
+
+    // Verify token replacement.
+    $account = $this->createUser();
+    $message->setOwner($account);
+    $message->save();
+    $text = $message->getText();
+    $this->assertEquals(1, count($text));
+    $this->assertEquals('<p>foo  and ' . $account->getUsername() . "</p>\n", $text[0]);
+
+    // Disable token processing.
+    $this->messageTemplate->setSettings([
+      'token options' => [
+        'token replace' => FALSE,
+        'clear' => TRUE,
+      ],
+    ]);
+    $this->messageTemplate->save();
+    $text = $message->getText();
+    $this->assertEquals(1, count($text));
+    $this->assertEquals('<p>foo [fake:token] and [message:author:name]</p>' . "\n", $text[0]);
+  }
+
+  /**
+   * Tests for getText argument handling.
+   *
+   * @covers ::getText
+   */
+  public function testGetTextArgumentProcessing() {
+    $this->messageTemplate->setSettings([
+      'token options' => [
+        'token replace' => FALSE,
+        'clear' => TRUE,
+      ],
+    ]);
+    $this->messageTemplate->set('text', [
+      [
+        'value' => '@foo @replace and @no_replace',
+        'format' => filter_default_format(),
+      ],
+      [
+        'value' => 'some @foo other @replace',
+        'format' => filter_default_format(),
+      ],
+    ]);
+    $this->messageTemplate->save();
+    $message = $this->entityTypeManager->getStorage('message')->create([
+      'template' => $this->messageTemplate->id(),
+      'arguments' => [
+        [
+          '@foo' => 'bar',
+          '@replace' => [
+            'pass message' => TRUE,
+            'arguments' => [
+              // When pass message is false, we'll use this text.
+              'bar_replacement',
+            ],
+            'callback' => [static::class, 'argumentCallback'],
+          ],
+        ],
+      ],
+    ]);
+    $message->save();
+    $text = $message->getText();
+    $this->assertEquals(2, count($text));
+    $this->assertEquals('<p>bar bar_replacement_' . $message->id() . ' and @no_replace</p>' . "\n", $text[0]);
+    $this->assertEquals('<p>some bar other bar_replacement_' . $message->id() . "</p>\n", $text[1]);
+
+    // Do not pass the message.
+    $message = $this->entityTypeManager->getStorage('message')->create([
+      'template' => $this->messageTemplate->id(),
+      'arguments' => [
+        [
+          '@foo' => 'bar',
+          '@replace' => [
+            'pass message' => FALSE,
+            'arguments' => [
+              // When pass message is false, we'll use this text.
+              'bar_replacement',
+            ],
+            'callback' => [static::class, 'argumentCallback'],
+          ],
+        ],
+      ],
+    ]);
+    $message->save();
+    $text = $message->getText();
+    $this->assertEquals(2, count($text));
+    $this->assertEquals('<p>bar bar_replacement and @no_replace</p>' . "\n", $text[0]);
+    $this->assertEquals('<p>some bar other bar_replacement' . "</p>\n", $text[1]);
+  }
+
+  /**
+   * Test callback method for ::testGetTextArgumentProcessing().
+   */
+  public static function argumentCallback($arg_1, MessageInterface $message = NULL) {
+    if ($message) {
+      // Use the message ID appended to replacement text.
+      $text = $arg_1 . '_' . $message->id();
+    }
+    else {
+      $text = $arg_1;
+    }
+    return $text;
   }
 
 }

--- a/tests/src/Kernel/MessageTokenTest.php
+++ b/tests/src/Kernel/MessageTokenTest.php
@@ -63,7 +63,7 @@ class MessageTokenTest extends KernelTestBase {
    */
   public function testTokenClearing() {
     // Clearing enabled.
-    $token_options = ['token options' => ['clear' => TRUE]];
+    $token_options = ['token options' => ['clear' => TRUE, 'token replace' => TRUE]];
     $message_template = $this->createMessageTemplate('dummy_message', 'Dummy message', '', ['[message:author:name] [bogus:token]'], $token_options);
     $message = Message::create(['template' => $message_template->id()])
       ->setOwnerId($this->user->id());
@@ -73,7 +73,7 @@ class MessageTokenTest extends KernelTestBase {
     $this->assertEquals('<p>' . Html::escape($this->user->label()) . ' </p>', (string) $message, 'The message rendered the author name and stripped unused tokens.');
 
     // Clearing disabled.
-    $token_options = ['token options' => ['clear' => FALSE]];
+    $token_options = ['token options' => ['clear' => FALSE, 'token replace' => TRUE]];
     $message_template->setSettings($token_options);
     $message_template->save();
 

--- a/tests/src/Unit/Entity/MessageTemplateTest.php
+++ b/tests/src/Unit/Entity/MessageTemplateTest.php
@@ -170,7 +170,7 @@ class MessageTemplateTest extends UnitTestCase {
     $this->assertEquals($expected, $this->messageTemplate->getText());
 
     // Test specific delta.
-    $this->assertEquals($expected[1], $this->messageTemplate->getText(Language::LANGCODE_NOT_SPECIFIED, 1));
+    $this->assertEquals([$expected[1]], $this->messageTemplate->getText(Language::LANGCODE_NOT_SPECIFIED, 1));
 
     // Non-existent delta.
     $this->assertEmpty($this->messageTemplate->getText(Language::LANGCODE_NOT_SPECIFIED, 42));


### PR DESCRIPTION
- Fixes #120
- Found several internal logic issues from the tests, and these have
  been fixed.

Note, this PR is against #120, so either needs to be merged into that prior to merge to 8.x, or just reviewed and moved to 8.x once #120 is merged.
