### PR TITLE
Fix message partial handling so that correct langcode is used.

### DIFF
--- a/src/Entity/Message.php
+++ b/src/Entity/Message.php
@@ -194,12 +194,15 @@ class Message extends ContentEntityBase implements MessageInterface {
   /**
    * {@inheritdoc}
    */
-  public function getText($langcode = Language::LANGCODE_NOT_SPECIFIED, $delta = NULL) {
+  public function getText($langcode = NULL, $delta = NULL) {
     if (!$message_template = $this->getTemplate()) {
       // Message template does not exist any more.
       // We don't throw an exception, to make sure we don't break sites that
       // removed the message template, so we silently ignore.
       return [];
+    }
+    if (!$langcode) {
+      $langcode = $this->language;
     }
 
     $message_arguments = $this->getArguments();

--- a/src/MessageViewBuilder.php
+++ b/src/MessageViewBuilder.php
@@ -19,12 +19,19 @@ class MessageViewBuilder extends EntityViewBuilder {
     if (!$langcode) {
       $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
     }
-    // Load the partials in the correct language.
-    $partials = $entity->getText($langcode);
-
-    if (\Drupal::moduleHandler()->moduleExists('config_translation') && !isset($partials[$langcode])) {
-      $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
+    else {
+      if (\Drupal::moduleHandler()->moduleExists('config_translation') && !isset($partials[$langcode])) {
+        $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
+      }
     }
+
+    // Load the partials in the correct language.
+    /* @var \Drupal\message\Entity\Message $entity  */
+    if ($langcode) {
+      $entity->setLanguage($langcode);
+    }
+    $partials = $entity->getText();
+
     $extra = '';
 
     // Get the partials the user selected for the current view mode.

--- a/src/MessageViewBuilder.php
+++ b/src/MessageViewBuilder.php
@@ -19,19 +19,12 @@ class MessageViewBuilder extends EntityViewBuilder {
     if (!$langcode) {
       $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
     }
-    else {
-      if (\Drupal::moduleHandler()->moduleExists('config_translation') && !isset($partials[$langcode])) {
-        $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
-      }
-    }
-
     // Load the partials in the correct language.
-    /* @var \Drupal\message\Entity\Message $entity  */
-    if ($langcode) {
-      $entity->setLanguage($langcode);
-    }
-    $partials = $entity->getText();
+    $partials = $entity->getText($langcode);
 
+    if (\Drupal::moduleHandler()->moduleExists('config_translation') && !isset($partials[$langcode])) {
+      $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
+    }
     $extra = '';
 
     // Get the partials the user selected for the current view mode.


### PR DESCRIPTION
Messages were always displayed with LANGCODE_NOT_SPECIFIED langcode. I'm not sure if this is same or related to #35 