### PR TITLE
HTML formatting is lost when delivering the message to user inbox.

### DIFF
--- a/src/MessageViewBuilder.php
+++ b/src/MessageViewBuilder.php
@@ -4,6 +4,7 @@ namespace Drupal\message;
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityViewBuilder;
+use Drupal\Component\Render\FormattableMarkup;
 
 /**
  * Render controller for Messages.
@@ -51,7 +52,7 @@ class MessageViewBuilder extends EntityViewBuilder {
       }
     }
 
-    $build['#markup'] = $extra;
+    $build['#markup'] = new FormattableMarkup($extra, []);
 
     return $build;
   }


### PR DESCRIPTION
I was testing emails with mailsystem + swiftmailer setup and the message module text was always escaped before message was delivered to user inbox, even after setting message format to html.

With this patch I managed to get correct formatting for html emails, but I'm not sure bigger refactoring is required here. Message notify email plugin had this comment 

> // @todo Centralize rendering.

so maybe there are other plans to fix this issue already?