### PR TITLE
Fix for code sniffer fail

### DIFF
--- a/message.module
+++ b/message.module
@@ -172,7 +172,7 @@ function message_theme() {
  *   - message: The message object.
  *   - view_mode: View mode; e.g., 'full', 'teaser', etc.
  */
-function template_preprocess_message(&$variables) {
+function template_preprocess_message(array &$variables) {
   $variables['view_mode'] = $variables['elements']['#view_mode'];
 
   // Provide a distinct $teaser boolean.


### PR DESCRIPTION
Here is a quick fix but,

I was unable to reproduce this same fail locally with both Drupal and DrupalPractice phpcs standard that come with the coder module. Where can I find that "Drupal Module" standard for local use?