### PR TITLE
Fix message_update_7013 failing on PostgreSQL.

### DIFF
--- a/message.install
+++ b/message.install
@@ -535,29 +535,38 @@ function message_update_7012() {
  * null'.
  */
 function message_update_7013() {
-  // Here we have some special concern:
-  // 1. Keep the field as serial so the auto_increment will not affected.
-  // 2. Before setting (or change) a field as serial PK should be dropped.
-  // 3. BTW, if change a serial field without any index will fail in MySQL.
+  $message = NULL;
+  if (db_driver() === 'pgsql') {
+    $message = 'Noting to change for PostgreSQL.';
+  }
+  else {
+    // Here we have some special concern:
+    // 1. Keep the field as serial so the auto_increment will not affected.
+    // 2. Before setting (or change) a field as serial PK should be dropped.
+    // 3. BTW, if change a serial field without any index will fail in MySQL.
 
-  // Let's add a temporary unique key for mid so MySQL will let it go.
-  db_add_unique_key('message', 'temp_key', array('mid'));
+    // Let's add a temporary unique key for mid so MySQL will let it go.
+    db_add_unique_key('message', 'temp_key', array('mid'));
 
-  // Now remove the PK before changing a field as serial (well, even it is
-  // already a serial field, originally).
-  db_drop_primary_key('message');
+    // Now remove the PK before changing a field as serial (well, even it is
+    // already a serial field, originally).
+    db_drop_primary_key('message');
 
-  // Here we can successfully alter the serial field without error message.
-  // See https://api.drupal.org/api/drupal/includes!database!database.inc/function/db_change_field/7
-  db_change_field('message', 'mid', 'mid', array(
-    'type' => 'serial',
-    'unsigned' => TRUE,
-    'description' => 'The Unique ID of the message.',
-    'not null' => TRUE,
-  ), array(
-    'primary key' => array('mid'),
-  ));
+    // Here we can successfully alter the serial field without error message.
+    // See https://api.drupal.org/api/drupal/includes!database!database.inc/function/db_change_field/7
+    db_change_field('message', 'mid', 'mid', array(
+      'type' => 'serial',
+      'unsigned' => TRUE,
+      'description' => 'The Unique ID of the message.',
+      'not null' => TRUE,
+    ), array(
+      'primary key' => array('mid'),
+    ));
 
-  // Finally, remove the temporary unique key because no longer useful.
-  db_drop_unique_key('message', 'temp_key');
+    // Finally, remove the temporary unique key because no longer useful.
+    db_drop_unique_key('message', 'temp_key');
+    $message = 'Successfully changed message.mid schema.';
+  }
+
+  return $message;
 }


### PR DESCRIPTION
Latest message update message_update_7013() is failing on PostgreSQL with :

> SQLSTATE[42P07]: Duplicate table: 7 ERROR:  relation "message_mid_seq" already exists.

because on PostgreSQL serial fields are not NULLs by default. Check Drupal driver for PostgreSQL here includes/database/pgsql/schema.inc:181 DatabaseSchema_pgsql::protected function createFieldSql()
```php
if (isset($spec['type']) && $spec['type'] == 'serial') {
  unset($spec['not null']);
}
```
and includes/database/pgsql/schema.inc:252 DatabaseSchema_pgsql::protected function processField()
```php
if (isset($field['type']) && $field['type'] == 'serial') {
      unset($field['not null']);
}
```
