### PR TITLE
Fix non-numeric value warning on PHP 7.1

### DIFF
--- a/src/MessagePurgeBase.php
+++ b/src/MessagePurgeBase.php
@@ -163,7 +163,7 @@ abstract class MessagePurgeBase extends PluginBase implements MessagePurgeInterf
   public function setConfiguration(array $configuration) {
     $configuration += [
       'data' => [],
-      'weight' => '',
+      'weight' => 0,
     ];
     $this->configuration = $configuration['data'] + $this->defaultConfiguration();
     $this->weight = $configuration['weight'];


### PR DESCRIPTION
Whenever I edit a message template I am getting multiple instances of the following warning on PHP 7.1:

```
Warning: A non-numeric value encountered in Drupal\Core\Render\Element::children() (line 95 of core/lib/Drupal/Core/Render/Element.php).
Drupal\Core\Render\Element::children(Array) (Line: 999)
Drupal\Core\Form\FormBuilder->doBuildForm('message_template_edit_form', Array, Object) (Line: 1045)
Drupal\Core\Form\FormBuilder->doBuildForm('message_template_edit_form', Array, Object) (Line: 1045)
Drupal\Core\Form\FormBuilder->doBuildForm('message_template_edit_form', Array, Object) (Line: 557)
Drupal\Core\Form\FormBuilder->processForm('message_template_edit_form', Array, Object) (Line: 314)
Drupal\Core\Form\FormBuilder->buildForm('message_template_edit_form', Object) (Line: 74)
Drupal\Core\Controller\FormController->getContentResult(Object, Object)
call_user_func_array(Array, Array) (Line: 123)
Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}() (Line: 618)
Drupal\Core\Render\Renderer->executeInRenderContext(Object, Object) (Line: 124)
Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->wrapControllerExecutionInRenderContext(Array, Array) (Line: 97)
Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}()
call_user_func_array(Object, Array) (Line: 144)
Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object, 1) (Line: 64)
Symfony\Component\HttpKernel\HttpKernel->handle(Object, 1, 1) (Line: 57)
Drupal\Core\StackMiddleware\Session->handle(Object, 1, 1) (Line: 47)
Drupal\Core\StackMiddleware\KernelPreHandle->handle(Object, 1, 1) (Line: 99)
Drupal\page_cache\StackMiddleware\PageCache->pass(Object, 1, 1) (Line: 78)
Drupal\page_cache\StackMiddleware\PageCache->handle(Object, 1, 1) (Line: 47)
Drupal\Core\StackMiddleware\ReverseProxyMiddleware->handle(Object, 1, 1) (Line: 50)
Drupal\Core\StackMiddleware\NegotiationMiddleware->handle(Object, 1, 1) (Line: 23)
Stack\StackedHttpKernel->handle(Object, 1, 1) (Line: 656)
Drupal\Core\DrupalKernel->handle(Object) (Line: 19)
```

This is because the weight is initialized to an empty string, but the weight should always be an integer value since it is used in numeric calculations.