### PR TITLE
Do not clone user in message_create when uid set

### DIFF
--- a/message.module
+++ b/message.module
@@ -886,7 +886,7 @@ function message_type_delete($message) {
  */
 function message_create($type, $values = array(), $account = NULL) {
   global $language;
-  if (empty($account)) {
+  if (empty($account) && empty($values['uid'])) {
     global $user;
     $account = clone $user;
   }


### PR DESCRIPTION
The optional `uid` entry in the `$values` argument to `message_create` overrides `$account` so there is no need to set a value when `uid` is set.