### PR TITLE
Do not default on translation that does not exist

### DIFF
--- a/src/MessageViewBuilder.php
+++ b/src/MessageViewBuilder.php
@@ -16,18 +16,18 @@ class MessageViewBuilder extends EntityViewBuilder {
   public function view(EntityInterface $entity, $view_mode = 'full', $langcode = NULL) {
     $build = parent::view($entity, $view_mode, $langcode);
 
-    // If language has not been set, and if message has translation for current
-    // language used by user, send message with current language.
+    // Ensure that wanted language exists for given message. If no langcode
+    // given, check if users current language exists for message.
     $current_language = \Drupal::languageManager()->getCurrentLanguage()->getId();
-    if (!$langcode && $entity->getText($current_language)) {
-      $langcode = $current_language;
+    /* @var \Drupal\message\Entity\Message $entity  */
+    if ($langcode && $entity->getText($langcode)) {
+      $entity->setLanguage($langcode);
+    }
+    elseif ($entity->getText($current_language)) {
+      $entity->setLanguage($current_language);
     }
 
     // Load the partials in the correct language.
-    /* @var \Drupal\message\Entity\Message $entity  */
-    if ($langcode) {
-      $entity->setLanguage($langcode);
-    }
     $partials = $entity->getText();
 
     // Get the partials the user selected for the current view mode.

--- a/src/MessageViewBuilder.php
+++ b/src/MessageViewBuilder.php
@@ -16,19 +16,8 @@ class MessageViewBuilder extends EntityViewBuilder {
   public function view(EntityInterface $entity, $view_mode = 'full', $langcode = NULL) {
     $build = parent::view($entity, $view_mode, $langcode);
 
-    // Ensure that wanted language exists for given message. If no langcode
-    // given, check if users current language exists for message.
-    $current_language = \Drupal::languageManager()->getCurrentLanguage()->getId();
     /* @var \Drupal\message\Entity\Message $entity  */
-    if ($langcode && $entity->getText($langcode)) {
-      $entity->setLanguage($langcode);
-    }
-    elseif ($entity->getText($current_language)) {
-      $entity->setLanguage($current_language);
-    }
-
-    // Load the partials in the correct language.
-    $partials = $entity->getText();
+    $partials = $entity->getText($langcode);
 
     // Get the partials the user selected for the current view mode.
     $extra_fields = entity_get_display('message', $entity->bundle(), $view_mode);

--- a/src/MessageViewBuilder.php
+++ b/src/MessageViewBuilder.php
@@ -16,13 +16,11 @@ class MessageViewBuilder extends EntityViewBuilder {
   public function view(EntityInterface $entity, $view_mode = 'full', $langcode = NULL) {
     $build = parent::view($entity, $view_mode, $langcode);
 
-    if (!$langcode) {
-      $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
-    }
-    else {
-      if (\Drupal::moduleHandler()->moduleExists('config_translation') && !isset($partials[$langcode])) {
-        $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
-      }
+    // If language has not been set, and if message has translation for current
+    // language used by user, send message with current language.
+    $current_language = \Drupal::languageManager()->getCurrentLanguage()->getId();
+    if (!$langcode && $entity->getText($current_language)) {
+      $langcode = $current_language;
     }
 
     // Load the partials in the correct language.


### PR DESCRIPTION
Fix defaulting on langcode when Message has no translation for that language.

This also covers fix for the bug that `$partials` has not been declared, so whatever you tried to set as langcode, the `if / else` -statement overrides it for current language.