### PR TITLE
Use the API to retrieve the first argument value

### DIFF
--- a/src/Entity/Message.php
+++ b/src/Entity/Message.php
@@ -133,10 +133,8 @@ class Message extends ContentEntityBase implements MessageInterface {
    * {@inheritdoc}
    */
   public function getArguments() {
-    $arguments = $this->get('arguments')->getValue();
-
-    // @todo: See if there is a easier way to get only the 0 key.
-    return $arguments ? $arguments[0] : [];
+    $arguments = $this->get('arguments')->first();
+    return $arguments ? $arguments->getValue() : [];
   }
 
   /**


### PR DESCRIPTION
This is a small fix that solves one of the `@todo`s in the Message entity.