### PR TITLE
Field UI tabs are not displayed in the template edit page

### DIFF
--- a/message.links.task.yml
+++ b/message.links.task.yml
@@ -7,3 +7,8 @@ messages.admin:
   title: Messages
   route_name: message.messages
   base_route: node.content_overview
+
+entity.message_template.edit_form:
+  title: 'Edit'
+  route_name: entity.message_template.edit_form
+  base_route: entity.message_template.edit_form


### PR DESCRIPTION
It was (wrongly) reported and fixed in https://www.drupal.org/project/message/issues/2911460. I only copied the fix from there after I manually tested.