### PR TITLE
Added a return for the Message save function.

### DIFF
--- a/src/Entity/Message.php
+++ b/src/Entity/Message.php
@@ -324,7 +324,7 @@ class Message extends ContentEntityBase implements MessageInterface {
     $arguments = $this->getArguments();
     $this->setArguments(array_merge($tokens, $arguments));
 
-    parent::save();
+    return parent::save();
   }
 
   /**


### PR DESCRIPTION
Hi, save function doesn't return the result as it's parent does.

I would like to know the result of the Message creation process.

Is it a feature or a bug?
