### PR TITLE
Improve performance of message_handler_field_message_render

### DIFF
--- a/includes/views/handlers/message_handler_field_message_render.inc
+++ b/includes/views/handlers/message_handler_field_message_render.inc
@@ -13,6 +13,20 @@
 class message_handler_field_message_render extends views_handler_field {
 
   /**
+   * {@inheritdoc}
+   */
+  public function construct() {
+    parent::construct();
+
+    // Add fields necessary to reconstruct Message entities
+    $this->additional_fields['mid']       = array('field' => 'mid');
+    $this->additional_fields['type']      = array('field' => 'type');
+    $this->additional_fields['arguments'] = array('field' => 'arguments');
+    $this->additional_fields['uid']       = array('field' => 'uid');
+    $this->additional_fields['timestamp'] = array('field' => 'timestamp');
+  }
+
+  /**
    * Set default field name to render.
    */
   function option_definition() {
@@ -71,14 +85,21 @@ class message_handler_field_message_render extends views_handler_field {
   }
 
   function render($values) {
-    $field_alias = $this->field_alias;
-    if (!empty($values->{$field_alias}) && $message = message_load($values->{$field_alias})) {
-      $options = array(
-        'field name' => $this->options['field_name'],
-        'partials' => $this->options['partials'],
-        'partial delta' => $this->options['partials_delta'],
-      );
-      return $message->getText(NULL, $options);
-    }
+    // reconstruct Message entity
+    $message_values = array(
+      'arguments' => unserialize($this->get_value($values, 'arguments')),
+      'timestamp' => $this->get_value($values, 'timestamp'),
+      'uid' => $this->get_value($values, 'uid'),
+    );
+
+    $message = message_create($this->get_value($values, 'type'), $message_values, $message_values['uid']);
+
+    $options = array(
+      'field name' => $this->options['field_name'],
+      'partials' => $this->options['partials'],
+      'partial delta' => $this->options['partials_delta'],
+    );
+
+    return $message->getText(NULL, $options);
   }
 }


### PR DESCRIPTION
We use Message as a dependency of Drupal Commerce on a large Drupal 7 site. At one point a views configuration for listing events attached to an order (represented as a set of messages) was altered to list all results for the view instead of using a pager. On a particularly troublesome order this resulted in a view of 290 rendered messages, which caused PHP memory exhaustion in production.

Analysis demonstrated that calling `message_load()` in order to load each message entity needing to be rendered was enormously expensive. This PR is a refactor of `class message_handler_field_message_render` that rebuilds the message entity using data pulled in from the view's SQL, avoiding unnecessary secondary loading of each message.

I've included XHProf results of the 290 message view with and without these modifications. Prior to modification, successful rendering of these messages required a php `memory_limit` in excess of 700MB and 77 seconds in my local dev environment. Afterward it easily fits in our production limit of 128MB and requires about 7 seconds.

Before:
![message_handler_field_message_render before](https://user-images.githubusercontent.com/17752261/42332754-b3b912e8-802d-11e8-9f70-d8ccceb08cb7.png)

After:
![message_handler_field_message_render after](https://user-images.githubusercontent.com/17752261/42332752-b39d4662-802d-11e8-8280-6d301ce288a8.png)
