### PR TITLE
Add check to Message::getText() to avoid unnecessary argument processing

### DIFF
--- a/includes/message.message.inc
+++ b/includes/message.message.inc
@@ -172,32 +172,35 @@ class Message extends Entity {
     if (!empty($arguments)) {
       $args = array();
       foreach ($arguments as $key => $value) {
-        if (is_array($value) && !empty($value['callback']) && function_exists($value['callback'])) {
-          // A replacement via callback function.
-          $value += array('pass message' => FALSE);
-          if ($value['pass message']) {
-            // Pass the message object as-well.
-            $value['callback arguments'][] = $this;
+        // Don't bother processing for keys not present in the output
+        if (strpos($output, $key) !== FALSE) {
+          if (is_array($value) && !empty($value['callback']) && function_exists($value['callback'])) {
+            // A replacement via callback function.
+            $value += array('pass message' => FALSE);
+            if ($value['pass message']) {
+              // Pass the message object as-well.
+              $value['callback arguments'][] = $this;
+            }
+
+            $value = call_user_func_array($value['callback'], $value['callback arguments']);
           }
 
-          $value = call_user_func_array($value['callback'], $value['callback arguments']);
-        }
+          switch ($key[0]) {
+            case '@':
+              // Escaped only.
+              $args[$key] = check_plain($value);
+              break;
 
-        switch ($key[0]) {
-          case '@':
-            // Escaped only.
-            $args[$key] = check_plain($value);
-            break;
+            case '%':
+            default:
+              // Escaped and placeholder.
+              $args[$key] = drupal_placeholder($value);
+              break;
 
-          case '%':
-          default:
-            // Escaped and placeholder.
-            $args[$key] = drupal_placeholder($value);
-            break;
-
-          case '!':
-            // Pass-through.
-            $args[$key] = $value;
+            case '!':
+              // Pass-through.
+              $args[$key] = $value;
+          }
         }
       }
       $output = strtr($output, $args);

--- a/includes/message.message.inc
+++ b/includes/message.message.inc
@@ -172,35 +172,37 @@ class Message extends Entity {
     if (!empty($arguments)) {
       $args = array();
       foreach ($arguments as $key => $value) {
-        // Don't bother processing for keys not present in the output
-        if (strpos($output, $key) !== FALSE) {
-          if (is_array($value) && !empty($value['callback']) && function_exists($value['callback'])) {
-            // A replacement via callback function.
-            $value += array('pass message' => FALSE);
-            if ($value['pass message']) {
-              // Pass the message object as-well.
-              $value['callback arguments'][] = $this;
-            }
+        if (strpos($output, $key) === FALSE) {
+          // The replacement key is not in the output, so save computation.
+          continue;
+        }
 
-            $value = call_user_func_array($value['callback'], $value['callback arguments']);
+        if (is_array($value) && !empty($value['callback']) && function_exists($value['callback'])) {
+          // A replacement via callback function.
+          $value += array('pass message' => FALSE);
+          if ($value['pass message']) {
+            // Pass the message object as-well.
+            $value['callback arguments'][] = $this;
           }
 
-          switch ($key[0]) {
-            case '@':
-              // Escaped only.
-              $args[$key] = check_plain($value);
-              break;
+          $value = call_user_func_array($value['callback'], $value['callback arguments']);
+        }
 
-            case '%':
-            default:
-              // Escaped and placeholder.
-              $args[$key] = drupal_placeholder($value);
-              break;
+        switch ($key[0]) {
+          case '@':
+            // Escaped only.
+            $args[$key] = check_plain($value);
+            break;
 
-            case '!':
-              // Pass-through.
-              $args[$key] = $value;
-          }
+          case '%':
+          default:
+            // Escaped and placeholder.
+            $args[$key] = drupal_placeholder($value);
+            break;
+
+          case '!':
+            // Pass-through.
+            $args[$key] = $value;
         }
       }
       $output = strtr($output, $args);


### PR DESCRIPTION
In `Message::getText()` all arguments are processed regardless of whether their keys are present in the message type's template. It is possible for expensive callbacks to exist in arguments that are not used.

For example, the Commerce Message module adds a callback (`commerce_message_order_summary`) to all messages that have a Commerce Order EntityReference which returns the output of a view. This causes each call to `Message::getText()` on an affected message to execute the view, even if the result is then ignored.

This PR adds a check to ensure that the argument key exists in the output and will be matched by `strtr()` before preparing the arguments for output, thus skipping any potentially expensive callbacks whose return values would go unused.