### PR TITLE
admin menu item for content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /vendor
 composer.lock
+.idea
+.DS_Store

--- a/message.links.menu.yml
+++ b/message.links.menu.yml
@@ -16,3 +16,9 @@ message.settings:
   description: 'Message settings.'
   parent: 'message.main_settings'
   route_name: message.settings
+
+message.admin_content:
+  title: 'Messages'
+  description: 'Display all messages.'
+  parent: 'system.admin_content'
+  route_name: message.messages


### PR DESCRIPTION
Add menu link for admin to view message content + some gitignores.

This appears to be a duplicate of https://www.drupal.org/project/message/issues/2911468 however I cannot see a PR here in this repo.