### PR TITLE
Fix tampering and errors during config sync.

### DIFF
--- a/src/Entity/MessageTemplate.php
+++ b/src/Entity/MessageTemplate.php
@@ -315,6 +315,11 @@ class MessageTemplate extends ConfigEntityBundleBase implements MessageTemplateI
    * {@inheritdoc}
    */
   public function preSave(EntityStorageInterface $storage) {
+    // Don't do anything during config sync.
+    if (\Drupal::isConfigSyncing()) {
+      return;
+    }
+
     $this->text = array_filter($this->text, function ($partial) {
       // Filter out any partials with an empty `value`.
       return !empty($partial['value']);


### PR DESCRIPTION
In Drupal 8, it's best practice to not tamper with configuration while a configuration sync is taking place (e.g. when someone is running `drush config-import`). When I say tampering, I'm talking about using hooks to modify configuration as it's being imported--in this case, creating translations whenever a message template is created/saved.

This leads to errors like this during config imports:
> Deleted and replaced configuration entity "message.template.foo"

The problem is that a project's configuration set will generally already contain both the message template and its translation. So the order of events during an import looks like this:
1. Drupal creates the base message template.
2. The creation of the message template invokes MessageTemplate::preSave().
3. preSave() creates a corresponding message template translation.
4. Drupal tries to import the (now duplicate) message template translation from disk.
5. Drupal sees that a message template translation already exists in active storage and barfs.

There are a lot of references in other issue queues about why this is necessary, a good place to start is here: https://www.drupal.org/project/lightning/issues/2870864